### PR TITLE
Add cobra_vendor package.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ ExternalProject_Add(cobra-3.6
   PREFIX cobra-3.6
   GIT_REPOSITORY https://github.com/nimble-code/cobra
   GIT_TAG ab06e676f9123ec07011a09c38daffaa4fbfdc60
-  INSTALL_DIR <SOURCE_DIR>/cobra_install
+  INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/cobra_install"
   BUILD_IN_SOURCE TRUE
   CONFIGURE_COMMAND ""
   BUILD_COMMAND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,17 +14,24 @@ ExternalProject_Add(cobra-3.6
   PREFIX cobra-3.6
   GIT_REPOSITORY https://github.com/nimble-code/cobra
   GIT_TAG ab06e676f9123ec07011a09c38daffaa4fbfdc60
-  INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/bin_linux"
+  INSTALL_DIR <SOURCE_DIR>/cobra_install
   BUILD_IN_SOURCE TRUE
   CONFIGURE_COMMAND ""
   BUILD_COMMAND
   ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make all
   INSTALL_COMMAND
-  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=/dev/null && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux && <SOURCE_DIR>/bin_linux/cobra -configure <SOURCE_DIR>
+  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=/dev/null && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
 )
 
 install(PROGRAMS
   ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/cobra
   DESTINATION bin)
+
+install(DIRECTORY 
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/rules
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_environment_hooks(env_hook/cobra_vendor_base.dsv.in)
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ ExternalProject_Add(cobra-3.6
 
 install(PROGRAMS
   ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/cobra
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/cwe
   DESTINATION bin)
 
 install(DIRECTORY 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(cobra_vendor NONE)
 
 find_package(ament_cmake REQUIRED)
 
-
 set(extra_cmake_args)
 
 if(DEFINED CMAKE_BUILD_TYPE)
@@ -15,13 +14,17 @@ ExternalProject_Add(cobra-3.6
   PREFIX cobra-3.6
   GIT_REPOSITORY https://github.com/nimble-code/cobra
   GIT_TAG ab06e676f9123ec07011a09c38daffaa4fbfdc60
-  INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/cobra_install"
+  INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/bin_linux"
   BUILD_IN_SOURCE TRUE
   CONFIGURE_COMMAND ""
   BUILD_COMMAND
   ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make all
   INSTALL_COMMAND
-  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=/dev/null && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
+  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=/dev/null && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux && <SOURCE_DIR>/bin_linux/cobra -configure <SOURCE_DIR>
 )
+
+install(PROGRAMS
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/cobra
+  DESTINATION bin)
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.16)
+project(cobra_vendor NONE)
+
+find_package(ament_cmake REQUIRED)
+
+
+set(extra_cmake_args)
+
+if(DEFINED CMAKE_BUILD_TYPE)
+  list(APPEND extra_cmake_args "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+endif()
+
+include(ExternalProject)
+ExternalProject_Add(cobra-3.6
+  PREFIX cobra-3.6
+  GIT_REPOSITORY https://github.com/nimble-code/cobra
+  GIT_TAG ab06e676f9123ec07011a09c38daffaa4fbfdc60
+  INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/cobra_install"
+  BUILD_IN_SOURCE TRUE
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND
+  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make all
+  INSTALL_COMMAND
+  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=/dev/null && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
+)
+
+ament_package()

--- a/env_hook/cobra_vendor_base.dsv.in
+++ b/env_hook/cobra_vendor_base.dsv.in
@@ -1,0 +1,1 @@
+set;C_BASE;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/rules

--- a/env_hook/cobra_vendor_base.sh
+++ b/env_hook/cobra_vendor_base.sh
@@ -1,0 +1,5 @@
+# copied from cobra_vendor/env_hook/cobra_vendor_base.sh
+
+#ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX"
+
+#ament_prepend_unique_value LD_LIBRARY_PATH "ThisIsTheValue"

--- a/env_hook/cobra_vendor_base.sh
+++ b/env_hook/cobra_vendor_base.sh
@@ -1,5 +1,0 @@
-# copied from cobra_vendor/env_hook/cobra_vendor_base.sh
-
-#ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX"
-
-#ament_prepend_unique_value LD_LIBRARY_PATH "ThisIsTheValue"

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>cobra_vendor</name>
+  <version>0.1.0</version>
+  <description>CMake shim providing the cobra project.</description>
+  <maintainer email="steven@openrobotics.org">Steven! Ragnarök</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Rather than continuing to host cobra_vendor separately we've agreed it makes sense to live as a sibling package to the ament_cobra wrapper.

This PR was produced using `git subtree add --prefix cobra_vendor https://github.com/nuclearsandwich/cobra_vendor latest` and so includes the complete git history of that project.