### PR TITLE
Install other programs

### DIFF
--- a/cobra_vendor/CMakeLists.txt
+++ b/cobra_vendor/CMakeLists.txt
@@ -26,6 +26,9 @@ ExternalProject_Add(cobra-3.6
 install(PROGRAMS
   ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/cobra
   ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/cwe
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/scope_check
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/find_taint
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/window.tcl
   DESTINATION bin)
 
 install(DIRECTORY 


### PR DESCRIPTION
It turns out that the scope_check binary is used by some of the rule sets. Since I need to install that one, might as well proactively install the others as well in case they are also used or someone wants to use them directly. 