### PR TITLE
Add the new json_convert utility

### DIFF
--- a/cobra_vendor/CMakeLists.txt
+++ b/cobra_vendor/CMakeLists.txt
@@ -24,7 +24,7 @@ ExternalProject_Add(cobra-${VER}
   BUILD_COMMAND
   ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make all
   INSTALL_COMMAND
-  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=/dev/null && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
+  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
 )
 
 install(PROGRAMS

--- a/cobra_vendor/CMakeLists.txt
+++ b/cobra_vendor/CMakeLists.txt
@@ -9,11 +9,15 @@ if(DEFINED CMAKE_BUILD_TYPE)
   list(APPEND extra_cmake_args "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 endif()
 
+# The Cobra source code version/revision numbers
+set(VER "3.9")
+set(REV "02518bf8f45e398a22ac3923716d8e7c78bc83c3")
+
 include(ExternalProject)
-ExternalProject_Add(cobra-3.6
-  PREFIX cobra-3.6
+ExternalProject_Add(cobra-${VER}
+  PREFIX cobra-${VER}
   GIT_REPOSITORY https://github.com/nimble-code/cobra
-  GIT_TAG ab06e676f9123ec07011a09c38daffaa4fbfdc60
+  GIT_TAG ${REV}
   INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/cobra_install"
   BUILD_IN_SOURCE TRUE
   CONFIGURE_COMMAND ""
@@ -24,15 +28,16 @@ ExternalProject_Add(cobra-3.6
 )
 
 install(PROGRAMS
-  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/cobra
-  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/cwe
-  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/scope_check
-  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/find_taint
-  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/bin_linux/window.tcl
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-${VER}/src/cobra-${VER}/bin_linux/cobra
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-${VER}/src/cobra-${VER}/bin_linux/cwe
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-${VER}/src/cobra-${VER}/bin_linux/json_convert
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-${VER}/src/cobra-${VER}/bin_linux/scope_check
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-${VER}/src/cobra-${VER}/bin_linux/find_taint
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-${VER}/src/cobra-${VER}/bin_linux/window.tcl
   DESTINATION bin)
 
 install(DIRECTORY 
-  ${CMAKE_CURRENT_BINARY_DIR}/cobra-3.6/src/cobra-3.6/rules
+  ${CMAKE_CURRENT_BINARY_DIR}/cobra-${VER}/src/cobra-${VER}/rules
   DESTINATION share/${PROJECT_NAME}
 )
 


### PR DESCRIPTION
The Cobra repo now has a json_convert utility that can convert Cobra's JSON output file to either JUnit XML or SARIF. 

* Updating the Cobra source revision to pick up this utility
* Adding the utility to the list of installed programs
* Removing MAN=/dev/null since it is failing (anyways, it's OK to install any man pages to the default location in case people want to use them to view Cobra usage)