### PR TITLE
Use Cobra's json_convert utility to generate SARIF output

### DIFF
--- a/ament_cobra/ament_cobra/main.py
+++ b/ament_cobra/ament_cobra/main.py
@@ -511,5 +511,4 @@ def write_sarif_file(sarif_file, report, duration, ruleset, skip=None):
 
 
 if __name__ == '__main__':
-    print('HERE2')
     sys.exit(main())

--- a/ament_cobra/ament_cobra/main.py
+++ b/ament_cobra/ament_cobra/main.py
@@ -42,7 +42,7 @@ def get_cobra_version(cobra_bin):
 
 def main(argv=sys.argv[1:]):
     extensions = ['c', 'cc', 'cpp', 'cxx']
-    basic_args = ['-C++', '-comments']
+    basic_args = ['-C++', '-comments', '-json']
 
     # The Cobra rulesets
     rulesets = ['basic', 'cwe', 'p10', 'jpl', 'misra2012']
@@ -89,6 +89,9 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--xunit-file',
         help='Generate a xunit compliant XML file')
+    parser.add_argument(
+        '--sarif-file',
+        help='Generate a SARIF file')
     parser.add_argument(
         '--cobra-version',
         action='store_true',
@@ -161,8 +164,7 @@ def main(argv=sys.argv[1:]):
     # Initialize the output report
     report = defaultdict(list)
 
-    if args.xunit_file:
-        start_time = time.time()
+    start_time = time.time()
 
     # For each group of files
     for group_name in sorted(groups.keys()):
@@ -198,9 +200,15 @@ def main(argv=sys.argv[1:]):
         print('%d errors' % error_count, file=sys.stderr)
         rc = 1
 
+    elapsed_time = time.time() - start_time
+
     # Generate the xunit output file
     if args.xunit_file:
-        write_xunit_file(args.xunit_file, report, time.time() - start_time)
+        write_xunit_file(args.xunit_file, report, elapsed_time)
+
+    # Generate the SARIF output file
+    if args.sarif_file:
+        write_sarif_file(args.sarif_file, report, elapsed_time, args.ruleset)
 
     return rc
 
@@ -468,5 +476,37 @@ def write_xunit_file(xunit_file, report, duration, skip=None):
         f.write(xml)
 
 
+def write_sarif_file(sarif_file, report, duration, ruleset, skip=None):
+    folder_name = os.path.basename(os.path.dirname(sarif_file))
+    file_name = os.path.basename(sarif_file)
+
+    input_filename_map = {
+        'basic': '_Basic_.txt', # OK
+        'cwe': None,            # Issue with Cobra: no text output in this case
+        'p10': '_P10.txt',      # OK
+        'jpl': '_JPL_.txt',     # OK
+        'misra2012': None,      # Issue with Cobra: no text output in this case
+    }
+
+    if input_filename_map[ruleset] is None:
+        print(f"Can't generate SARIF file: no input file for ruleset: {ruleset}")
+        return 0
+
+    # Cobra uses a "_<upper-ruleset-name>_.txt" naming convention for its output file,
+    # which is the input file for the JSON-to-SARIF conversion
+    input_filename = os.path.join(folder_name, input_filename_map[ruleset])
+
+    cmd = ['json_convert', '-sarif', '-f', input_filename]
+    try:
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        cmd_output = p.communicate()[0]
+        with open(sarif_file, 'w') as f:
+            f.write(cmd_output.decode("utf-8"))
+    except subprocess.CalledProcessError as e:
+        print("'json_convert' failed with error code %d: %s" % (e.returncode, e), file=sys.stderr)
+        return 1
+
+
 if __name__ == '__main__':
+    print('HERE2')
     sys.exit(main())

--- a/cobra_vendor/CMakeLists.txt
+++ b/cobra_vendor/CMakeLists.txt
@@ -24,7 +24,7 @@ ExternalProject_Add(cobra-${VER}
   BUILD_COMMAND
   ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make all
   INSTALL_COMMAND
-  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
+  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=/tmp && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
 )
 
 install(PROGRAMS

--- a/cobra_vendor/CMakeLists.txt
+++ b/cobra_vendor/CMakeLists.txt
@@ -24,7 +24,7 @@ ExternalProject_Add(cobra-${VER}
   BUILD_COMMAND
   ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make all
   INSTALL_COMMAND
-  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=/tmp && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
+  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=<SOURCE_DIR>/src_app && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
 )
 
 install(PROGRAMS


### PR DESCRIPTION
* Add the '-json' Cobra command-line option to get JSON output instead of the normal unstructured text output
* Add a --sarif-file command line option to ament_cobra
* Implement the write_sarif_file function in ament_cobra, which uses the json_convert utility

Fixes: https://github.com/space-ros/space-ros/issues/19