### PR TITLE
Cobra requires yacc (provided by bison) to build.

### DIFF
--- a/cobra_vendor/package.xml
+++ b/cobra_vendor/package.xml
@@ -9,6 +9,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>bison</build_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
A recent build of cobra_vendor failed for me and it turned out that there was an undeclared dependency on yacc/bison which was being masked by a bison dependency in cyclonedds.
The cyclonedds dependency was removed which exposed the issue.

It might be worth checking for other masked build dependencies for cobra in a follow-up PR.

```
--- stderr: cobra_vendor
Cloning into 'cobra-3.9'...
Note: switching to 'f1fb5915dd86fb6704204e83fd2f212667d33cc5'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at f1fb591 update
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: yacc: Command not found
make[3]: *** [makefile:84: cobra_eval.c] Error 127
make[2]: *** [CMakeFiles/cobra-3.9.dir/build.make:112: cobra-3.9/src/cobra-3.9-stamp/cobra-3.9-build] Error 2
make[1]: *** [CMakeFiles/Makefile2:78: CMakeFiles/cobra-3.9.dir/all] Error 2
make: *** [Makefile:129: all] Error 2
```