### PR TITLE
Install manual pages to install directory.

### DIFF
--- a/cobra_vendor/CMakeLists.txt
+++ b/cobra_vendor/CMakeLists.txt
@@ -24,7 +24,7 @@ ExternalProject_Add(cobra-${VER}
   BUILD_COMMAND
   ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make all
   INSTALL_COMMAND
-  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
+  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=<SOURCE_DIR>/src_app && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
 )
 
 install(PROGRAMS


### PR DESCRIPTION
This does not actually propagate the manual pages to the vendored installation but it is necessary to retarget the manual page installation to avoid polluting the root filesystem when building this vendor package as the manual page installation defaults to `/usr/share/man/man1`. On most of our build machines that is (correctly) not a writeable directory by the build user.