### PR TITLE
Use the latest Cobra source

### DIFF
--- a/cobra_vendor/CMakeLists.txt
+++ b/cobra_vendor/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 # The Cobra source code version/revision numbers
 set(VER "4.0")
-set(REV "d2574d0cc6608e22e3c68f92e392d1f293cb043e")
+set(REV "c1c994ab48e984ed4480efab4cf77448679553ca")
 
 include(ExternalProject)
 ExternalProject_Add(cobra-${VER}


### PR DESCRIPTION
which fixes json_convert truncating output messages. 

The json_convert tool is used to convert from JSON to SARIF and/or JUnit XML. The latest Cobra commit fixes this item, as reported here: https://github.com/nimble-code/Cobra/pull/52. 

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>