### PR TITLE
Fix compilation with ikos-scan-cc (#17).

### DIFF
--- a/cobra_vendor/CMakeLists.txt
+++ b/cobra_vendor/CMakeLists.txt
@@ -22,9 +22,9 @@ ExternalProject_Add(cobra-${VER}
   BUILD_IN_SOURCE TRUE
   CONFIGURE_COMMAND ""
   BUILD_COMMAND
-  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make all
+  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make linux && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make all LDFLAGS=-Wl,c.ar\ -pthread
   INSTALL_COMMAND
-  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=<SOURCE_DIR>/src_app && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux
+  ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install_linux MAN=<SOURCE_DIR>/src_app LDFLAGS=-Wl,c.ar\ -pthread && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src_app make install_linux LDFLAGS=-Wl,c.ar\ -pthread
 )
 
 install(PROGRAMS


### PR DESCRIPTION
This commit fixes compilation with [ikos-scan-cc compiler](https://github.com/NASA-SW-VnV/ikos), by modifying linker flags. Refer to problem B described in https://github.com/space-ros/docker/issues/138 for more details. I have verified that compilation works fine with `gcc` and `clang` after adding these flags.

Of course, I can create a separate issue for this in ament cobra repo if needed. I am also open to alternative solutions (e.g. modifying cobra makefile).